### PR TITLE
Migrate to Django 1.9

### DIFF
--- a/froala_editor/urls.py
+++ b/froala_editor/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from froala_editor import views
 
-urlpatterns = patterns('',
-                       url(r'^image_upload/$', views.image_upload, name='froala_editor_image_upload'),
-                       url(r'^file_upload/$', views.file_upload, name='froala_editor_file_upload'),
-)
+urlpatterns = [
+    url(r'^image_upload/$', views.image_upload, name='froala_editor_image_upload'),
+    url(r'^file_upload/$', views.file_upload, name='froala_editor_file_upload'),
+]


### PR DESCRIPTION
- RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated
  and will be removed in Django 1.10. Update your urlpatterns to be a
  list of django.conf.urls.url() instances instead.
    url(r'^file_upload/$', views.file_upload,
    name='froala_editor_file_upload'),