### PR TITLE
Fixing setup.py readme reference

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     url='http://github.com/froala/django-froala-editor/',
     license='BSD License',
     description='django-froala-editor package helps integrate Froala WYSIWYG HTML editor with Django.',
-    long_description=open('README.rst').read(),
+    long_description=open('README.md').read(),
     include_package_data=True,
     zip_safe=False,
     keywords='froala,django,admin,wysiwyg,editor,text,html,editor,rich, web',


### PR DESCRIPTION
`setup.py` had a reference to old `README.rst` file, so I could not install it. I'm installing it directly via github, since the one on pypi is outdated.

N.B.: the pypi HTML page shows that version 2.3.4 is the latest version, but the page used by `pip` (https://pypi.python.org/simple/django-froala-editor/) shows that the latest version there is `2.0.1`.