### PR TITLE
Fix for tool windows like insert URL (overflow and the labels within).

### DIFF
--- a/froala_editor/static/froala_editor/css/froala-django.css
+++ b/froala_editor/static/froala_editor/css/froala-django.css
@@ -11,3 +11,10 @@ form .fr-element p {
     clear: both;
 }
 
+div.form-row {
+    overflow: visible;
+}
+
+.aligned label:not(.vCheckboxLabel):after {
+    content: none;
+}


### PR DESCRIPTION
Related to reported issue #47, this CSS fixes the django froala editor for me.

Before the fix:
<img width="601" alt="before" src="https://user-images.githubusercontent.com/415535/36909286-e421c1b6-1e3d-11e8-9fc5-b3bf259d7212.png">

After the fix:
<img width="564" alt="after" src="https://user-images.githubusercontent.com/415535/36909292-e8d827ae-1e3d-11e8-8526-96b12d355481.png">

Please, also test on your end with applicable django versions.