### PR TITLE
Update z-index of froala editor view

### DIFF
--- a/froala_editor/static/froala_editor/css/froala-django.css
+++ b/froala_editor/static/froala_editor/css/froala-django.css
@@ -9,4 +9,5 @@ form .fr-element p {
 
 .fr-box {
     clear: both;
+    z-index: 0;
 }


### PR DESCRIPTION
This is to avoid overlapping of the django calendar view with the froala wysiwyg editor.
![2018-05-03_17h48_44](https://user-images.githubusercontent.com/10447738/39587779-9e80ce20-4efa-11e8-8599-e116cd3de353.png)
