### PR TITLE
Fix console error

### DIFF
--- a/froala_editor/static/froala_editor/js/froala-django.js
+++ b/froala_editor/static/froala_editor/js/froala-django.js
@@ -14,7 +14,7 @@ function getCookie(name) {
   return cookieValue;
 }
 
-if (typeof django !== 'undefined') {
+if (typeof django !== 'undefined' && typeof django.jQuery !== 'undefined') {
   (function ($) {
     $(document).on('formset:added', function (event, $row, formsetName) {
       $row.find('textarea').each(function () {


### PR DESCRIPTION
<img width="481" alt="screenshot_js_error_froala" src="https://user-images.githubusercontent.com/979082/50669690-8c993600-102b-11e9-8c4f-cf5b31b00a8c.png">

Hi guys,

I noticed js error in the console after I installed froala widget, please see the screenshot attached. 

PR includes simple precheck to make sure jQuery has loaded

