### PR TITLE
Fix django admin site form related field style

### DIFF
--- a/froala_editor/static/froala_editor/css/froala-django.css
+++ b/froala_editor/static/froala_editor/css/froala-django.css
@@ -10,7 +10,7 @@ form .fr-element p {
 .fr-box {
     clear: both;
     z-index: 1;
-    margin-top: 10px;
+    padding-top: 10px;
 }
 
 div.form-row {

--- a/froala_editor/static/froala_editor/css/froala-django.css
+++ b/froala_editor/static/froala_editor/css/froala-django.css
@@ -10,6 +10,7 @@ form .fr-element p {
 .fr-box {
     clear: both;
     z-index: 1;
+    margin-top: 10px;
 }
 
 div.form-row {
@@ -18,4 +19,10 @@ div.form-row {
 
 .aligned label:not(.vCheckboxLabel):after {
     content: none;
+}
+
+
+.related-widget-wrapper {
+    float: unset;
+    display: inline-block;
 }


### PR DESCRIPTION
Related to reported issue issue #70, this CSS fixes the django admin site form related and text field style bug

Before the fix:
![befor](https://user-images.githubusercontent.com/32626585/65217079-9a251c00-dae5-11e9-852d-d0e663d345a0.png)

After the fix:
![after](https://user-images.githubusercontent.com/32626585/65217085-a14c2a00-dae5-11e9-9079-ccbb1f53ba5c.png)

