### PR TITLE
fix hidden required field (fixes #68)

### DIFF
--- a/froala_editor/widgets.py
+++ b/froala_editor/widgets.py
@@ -99,3 +99,7 @@ class FroalaEditor(widgets.Textarea):
         return Media(css=css, js=js)
 
     media = property(_media)
+
+    def use_required_attribute(self, initial):
+        # textarea is hidden so HTML5 validation won't work properly
+        return False


### PR DESCRIPTION
This uses a feature added in Django 1.10 so it only works for that version and newer.