### PR TITLE
Updating urls.py to be Django 2.0 through 4.0 compatibile

### DIFF
--- a/froala_editor/urls.py
+++ b/froala_editor/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import re_path
 from froala_editor import views
 
 urlpatterns = [
-    url(r'^image_upload/$', views.image_upload, name='froala_editor_image_upload'),
-    url(r'^file_upload/$', views.file_upload, name='froala_editor_file_upload'),
+    re_path(r'^image_upload/$', views.image_upload, name='froala_editor_image_upload'),
+    re_path(r'^file_upload/$', views.file_upload, name='froala_editor_file_upload'),
 ]


### PR DESCRIPTION
Django 2.0 introduced the new `django.urls.re_path` function for url dispatching to replace the old `django.conf.urls.url` function. The urls.py file within django-froala-editor was last updated to Django 1.9 which is dead and `django.conf.urls.url` will be removed in Django 4.0 therefore updating now will support not only the current LTS release of 2.2 but both the soon-to-be released 3.2 LTS release as well as Django 4.0