### PR TITLE
Don't refer to files that doesn't exist anymore

### DIFF
--- a/froala_editor/widgets.py
+++ b/froala_editor/widgets.py
@@ -76,10 +76,9 @@ class FroalaEditor(widgets.Textarea):
 
     def _media(self):
         css = {
-            'all': ('froala_editor/css/froala_editor.min.css', 'froala_editor/css/froala_style.min.css',
-                    'froala_editor/css/froala-django.css')
+            'all': ('froala_editor/css/froala_editor.min.css', 'froala_editor/css/froala_style.min.css',)
         }
-        js = ('froala_editor/js/froala_editor.min.js', 'froala_editor/js/froala-django.js',)
+        js = ('froala_editor/js/froala_editor.min.js',)
 
         if self.theme:
             css['all'] += ('froala_editor/css/themes/' + self.theme + '.min.css',)


### PR DESCRIPTION
Version 4.0.4 deleted these files but they were still refered to in `_media` function.

Strangely looks like this bug from 2017 : #43