### PR TITLE
Fix for bug #97

### DIFF
--- a/froala_editor/static/froala_editor/js/froala-django.js
+++ b/froala_editor/static/froala_editor/js/froala-django.js
@@ -18,8 +18,9 @@ if (typeof django !== 'undefined' && typeof django.jQuery !== 'undefined') {
   (function ($) {
     $(document).on('formset:added', function (event, $row, formsetName) {
       $row.find('textarea').each(function () {
-        $(this).prev().remove();
-        jQuery(this).froalaEditor();
+        var froala_script = this.nextElementSibling.innerText.replace('__prefix__', this.closest('tr').id.split('-')[-1]);
+        this.parentElement.innerHTML = this.outerHTML;
+        django.jQuery(this.closest('td')).append("<script>" + froala_script + "</script>");
       });
     });
   })(django.jQuery);


### PR DESCRIPTION
The previous version broke Django Formsets as the prefix was not being replaced in the Froala initialiser so the above code replaces __prefix__ with the correct prefix count based on the table rows suffix