### PR TITLE
Added image/webp to allowed image types

### DIFF
--- a/froala_editor/views.py
+++ b/froala_editor/views.py
@@ -24,7 +24,8 @@ def image_upload(request):
             'image/pjpeg',
             'image/x-png',
             'image/png',
-            'image/gif'
+            'image/gif',
+            'image/webp'
         ]
         if not the_file.content_type in allowed_types:
             return HttpResponse(json.dumps({'error': _('You can only upload images.')}),


### PR DESCRIPTION
Address Issue #78 image/webp should be added to allowed image types. This is in sync with webp being in the default list of accepted types: https://www.froala.com/wysiwyg-editor/docs/options#imageAllowedTypes